### PR TITLE
overwrite the original query revision timeout with wait

### DIFF
--- a/remote/common.go
+++ b/remote/common.go
@@ -44,6 +44,8 @@ const (
 	OperationLeaseRenew  = "LEASE_RENEW"
 	OperationLeaseRevoke = "LEASE_REVOKE"
 	OperationSyncMembers = "SYNC"
+
+	QueryParamWait = "wait"
 )
 
 func max(n1, n2 int64) int64 {


### PR DESCRIPTION
If the etcd connection fails, overwrite the original query revision timeout with wait